### PR TITLE
Remove the check whether proj4 is an object

### DIFF
--- a/proj4-fully-loaded.js
+++ b/proj4-fully-loaded.js
@@ -1,7 +1,7 @@
 let proj4 = require("proj4");
 const defs = require("proj4js-definitions");
 
-if (typeof proj4 === "object" && typeof proj4.defs !== "function" && typeof proj4.default === "function") {
+if (typeof proj4.defs !== "function" && typeof proj4.default === "function") {
   // probably inside an Angular project
   proj4 = proj4.default;
 }


### PR DESCRIPTION
This PR removes a check which seems to be incompatible with Rollup. I wrote more details here: https://github.com/GeoTIFF/georaster-layer-for-leaflet/issues/109

I believe the removal of this check does not have negative consequences. If one of the remaining conditions, `typeof proj4.defs !== "function"`,  is satisfied, then unless the body of the `if` is executed, the line below (`proj4.defs(defs);`) will fail. So doing the additional check (which I propose to remove) does not affect whether the code will throw an error.